### PR TITLE
Update fieldPath regex

### DIFF
--- a/syntaxes/index.schema.json
+++ b/syntaxes/index.schema.json
@@ -23,7 +23,7 @@
                      "properties": {
                         "fieldPath": {
                            "type": "string",
-                           "pattern": "^[a-zA-Z0-9_\/]+$",
+                           "pattern": "^[a-zA-Z0-9_\/\.]+$",
                            "description": "The path of the field. Special field paths __name__, __type__, and __scatter__ may be used."
                         },
                         "mode": {


### PR DESCRIPTION
"." is a valid member of a fieldPath

For example for this doc:
```
{
  name: "sam",
  favorites: {
    food: "pizza"
  }
}
```

I could want an index on `"favorites.food"`