### PR TITLE
Allow "-" in collection group ID

### DIFF
--- a/syntaxes/index.schema.json
+++ b/syntaxes/index.schema.json
@@ -9,7 +9,7 @@
             "properties": {
                "collectionGroup": {
                   "type": "string",
-                  "pattern": "^[a-zA-Z0-9_]+$",
+                  "pattern": "^[a-zA-Z0-9_-]+$",
                   "description": "The collection group ID to which this index applies."
                },
                "queryScope": {
@@ -52,7 +52,7 @@
             "properties": {
                "collectionGroup": {
                   "type": "string",
-                  "pattern": "^[a-zA-Z0-9_]+$",
+                  "pattern": "^[a-zA-Z0-9_-]+$",
                   "description": "The collection group ID to which this field override applies."
                },
                "fieldPath": {


### PR DESCRIPTION
It looks like Firestore allows the use of "-" in collection names, at least it's working on my application. This PR fixes the schema for the indexes file to support it as well.