### PR TITLE
Fix required fields for `fieldOverrides`

### DIFF
--- a/syntaxes/index.schema.json
+++ b/syntaxes/index.schema.json
@@ -79,12 +79,12 @@
                         }
                      },
                      "uniqueItems": true,
-                     "required": ["order", "queryScope"]
+                     "required": ["queryScope"]
                   },
                   "minItems": 0
                }
             },
-            "required": ["collectionGroup", "queryScope", "fields"]
+            "required": ["indexes"]
          },
          "minItems": 0
       }


### PR DESCRIPTION
This addresses some false-warnings with valid indexes JSON, see #24